### PR TITLE
feature: use local jq command in create lambda layer if found

### DIFF
--- a/lambda/scripts/create_lambda_layer.sh
+++ b/lambda/scripts/create_lambda_layer.sh
@@ -52,5 +52,10 @@ cp "${REQUIREMENTS_FILE}" "${DEST_DIR}"
   rm -rf python/bin
 
   # Return JSON for Terraform
-  docker run -i stedolan/jq -n --arg path "${DEST_DIR}" '{"path":$path}'
+  if ! command -v jq &> /dev/null
+  then
+    docker run -i stedolan/jq -n --arg path "${DEST_DIR}" '{"path":$path}'
+  else
+    jq -n --arg path "${DEST_DIR}" '{"path":$path}'
+  fi
 )


### PR DESCRIPTION
In script create_lambda_layer.sh we try to use local installed jq command if it exists instead to download a docker image